### PR TITLE
change docs link ftp->https

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -24,7 +24,7 @@ Options:
 ## Subcommand Inputs
 | Subcommand     | Input Type                          | File types      |Description |
 |----------------|-------------------------------------|-----------------|------------|
-| call-reads     | Aligned HiFi reads                  | BAM             | Call Class I (ABC) from HiFi reads aligned to [GRCH38 no alts](ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz) | 
+| call-reads     | Aligned HiFi reads                  | BAM             | Call Class I (ABC) from HiFi reads aligned to [GRCH38 no alts](https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz) | 
 | call-contigs   | Aligned assembly; unaligned contigs | BAM, FASTA(.gz) | Extract and Call HLA loci from assembled MHC contigs                                         |
 | call-consensus | Amplicon/Isoseq consensus           | FASTA           | Call HLA alleles from consensus sequences (e.g. amplicon assays)                             |
 | align-imgt     | Sequence/IMGT accessions            | FASTA           | Compare sequences in fasta format or database sequences to specific IMGT/HLA genomic alleles |

--- a/docs/usage_call-contigs.md
+++ b/docs/usage_call-contigs.md
@@ -1,6 +1,6 @@
 ### Type HLA from MHC assembled contigs
 `call-contigs` requires 2 or 3 input files and an output directory:
- * Assembled contigs must be aligned to [GRCH38 no alts](ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz)
+ * Assembled contigs must be aligned to [GRCH38 no alts](https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz)
  * Assembled haplotype fasta[.gz] files (1 or 2)  
 
 Options:

--- a/docs/usage_call-reads.md
+++ b/docs/usage_call-reads.md
@@ -32,7 +32,7 @@ Presets:
   --preset <PRESET>  Sequence type presets [possible values: te, wgs]
 ```
 #### Input Options Description
-* `--abam` HiFi reads aligned to [GRCH38 no alts](ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz).
+* `--abam` HiFi reads aligned to [GRCH38 no alts](https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz).
 * `--loci` HLA loci to call. Currently limited to HLA-A,HLA-B,HLA-C.
 * `--max_depth` Maximim reads to use per locus. Reads are randomly downsampled if coverage > d.
 * `--partial` Include HiFi reads that do not fully span locus, but still span exon 2 (minimum requirement).


### PR DESCRIPTION
github was not renderinf the GRCh38_no_alt link as ftp.  Changed to https.